### PR TITLE
Tag overlay requests with IDs and support multiple origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ To persist across restarts, serialize the jar to disk later.
 CSS url() + srcset rewriting
 
 Backgrounds, sprites, fonts, and responsive images are now proxied (even when using relative paths), which reduces CORS/CSP friction and avoids broken assets.
+
+## Configuration
+
+Each overlay entry supports an optional `origins` array listing additional domains used by that overlay (for APIs, WebSockets, etc.). Requests to these domains will be tagged with the overlay ID so cookies and headers are routed correctly.

--- a/config/default.json
+++ b/config/default.json
@@ -5,6 +5,7 @@
     {
       "id": "Twitchat",
       "url": "...",
+      "origins": [],
       "x": 0,
       "y": 0,
       "width": 1920,
@@ -18,6 +19,7 @@
     {
       "id": "blerps",
       "url": "...",
+      "origins": [],
       "x": 0,
       "y": 0,
       "width": 1920,
@@ -31,6 +33,7 @@
     {
       "id": "streamelements",
       "url": "...",
+      "origins": [],
       "x": 0,
       "y": 0,
       "width": 1920,


### PR DESCRIPTION
## Summary
- Track active overlay while running DOM scripts so all subsequent requests are tagged
- Allow overlays to declare extra `origins` and proxy same-origin fetch/XHR/WS requests with overlay IDs
- Add generic server route to forward `?overlay=` requests to the correct upstream host

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ced938fb883308123e18a968a29f0