### PR TITLE
Tag light DOM requests with overlay IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ To persist across restarts, serialize the jar to disk later.
 CSS url() + srcset rewriting
 
 Backgrounds, sprites, fonts, and responsive images are now proxied (even when using relative paths), which reduces CORS/CSP friction and avoids broken assets.
+
+## Configuration
+
+Each overlay entry supports an optional `origins` array listing additional domains used by that overlay (for APIs, WebSockets, etc.). Requests to these domains will be tagged with the overlay ID so cookies and headers are routed correctly.

--- a/config/default.json
+++ b/config/default.json
@@ -5,6 +5,7 @@
     {
       "id": "Twitchat",
       "url": "...",
+      "origins": [],
       "x": 0,
       "y": 0,
       "width": 1920,
@@ -18,6 +19,7 @@
     {
       "id": "blerps",
       "url": "...",
+      "origins": [],
       "x": 0,
       "y": 0,
       "width": 1920,
@@ -31,6 +33,7 @@
     {
       "id": "streamelements",
       "url": "...",
+      "origins": [],
       "x": 0,
       "y": 0,
       "width": 1920,

--- a/public/compositor.mjs
+++ b/public/compositor.mjs
@@ -6,6 +6,11 @@ window.overlayConfig = config; // if not already set
 window.__ovOriginMap = {};
 for (const ov of (config.overlays || [])) {
   try { window.__ovOriginMap[new URL(ov.url).origin] = ov.id; } catch {}
+  if (Array.isArray(ov.origins)) {
+    for (const o of ov.origins) {
+      try { window.__ovOriginMap[new URL(o).origin] = ov.id; } catch {}
+    }
+  }
 }
 installRuntimeShims(window.__ovOriginMap);
 
@@ -30,30 +35,38 @@ function makeHost(ov){
   return host;
 }
 
-async function executeScriptsSequentially(container) {
-  const scripts = Array.from(container.querySelectorAll('script'));
-  for (const old of scripts) {
-    const s = document.createElement('script');
+async function executeScriptsSequentially(container, overlayId) {
+  const prev = window.__ovActiveOverlay;
+  window.__ovActiveOverlay = overlayId;
+  try {
+    const scripts = Array.from(container.querySelectorAll('script'));
+    for (const old of scripts) {
+      const s = document.createElement('script');
 
-    // Copy attributes (type, async, defer, crossorigin, etc.)
-    for (const attr of old.getAttributeNames()) {
-      s.setAttribute(attr, old.getAttribute(attr));
-    }
+      // Copy attributes (type, async, defer, crossorigin, etc.)
+      for (const attr of old.getAttributeNames()) {
+        s.setAttribute(attr, old.getAttribute(attr));
+      }
 
-    if (old.src) {
-      // External script: load and wait before continuing
-      await new Promise((resolve, reject) => {
-        s.onload = resolve;
-        s.onerror = reject;
-        s.src = old.src;     // already rewritten to /proxy
+      if (old.src) {
+        // External script: load and wait before continuing
+        await new Promise((resolve, reject) => {
+          s.onload = resolve;
+          s.onerror = reject;
+          s.src = old.src;     // already rewritten to /proxy
+          old.replaceWith(s);
+        });
+      } else {
+        // Inline script: execute immediately, in-order
+        s.textContent = old.textContent;
         old.replaceWith(s);
-      });
-    } else {
-      // Inline script: execute immediately, in-order
-      s.textContent = old.textContent;
-      old.replaceWith(s);
-      // no await needed; runs synchronously
+        // no await needed; runs synchronously
+      }
     }
+  } finally {
+    const id = overlayId;
+    window.__ovLastOverlay = { id, t: performance.now() };
+    window.__ovActiveOverlay = prev;
   }
 }
 
@@ -112,8 +125,8 @@ function installRuntimeShims(originToId){
         // never touch our control bus
         if (u.pathname === '/_control') return new OrigWS(url, protocols);
 
-        // SAME HOST: if it's /socket.io, just add overlay=<id> and connect locally
-        if (u.host === location.host && u.pathname.startsWith('/socket.io')) {
+        // SAME HOST: add overlay=<id> and connect locally
+        if (u.host === location.host) {
           const withId = addOverlayParam(u);
           console.debug('[shim][ws][local] ->', withId);
           return new OrigWS(withId, protocols);
@@ -144,22 +157,24 @@ function installRuntimeShims(originToId){
         const req = (input instanceof Request) ? input : new Request(input, init);
         const u = new URL(req.url, ORIGIN);
 
-        // same-origin /socket.io polling -> add overlay=<id>
-        if (u.origin === ORIGIN && u.pathname.startsWith('/socket.io')) {
+        // same-origin -> add overlay=<id>
+        if (u.origin === ORIGIN) {
           const id = pickOverlayIdFor(u.toString());
-          if (id) u.searchParams.set('overlay', id);
-          const cloned = new Request(u.toString(), {
-            method: req.method,
-            headers: req.headers,
-            body: (req.method === 'GET' || req.method === 'HEAD') ? undefined : req.body,
-            redirect: req.redirect,
-            referrer: req.referrer, referrerPolicy: req.referrerPolicy,
-            mode: 'same-origin', credentials: 'include',
-            cache: req.cache, integrity: req.integrity,
-            keepalive: req.keepalive, signal: req.signal,
-          });
-          console.debug('[shim][fetch][local] ->', u.toString());
-          return origFetch(cloned);
+          if (id) {
+            u.searchParams.set('overlay', id);
+            const cloned = new Request(u.toString(), {
+              method: req.method,
+              headers: req.headers,
+              body: (req.method === 'GET' || req.method === 'HEAD') ? undefined : req.body,
+              redirect: req.redirect,
+              referrer: req.referrer, referrerPolicy: req.referrerPolicy,
+              mode: 'same-origin', credentials: 'include',
+              cache: req.cache, integrity: req.integrity,
+              keepalive: req.keepalive, signal: req.signal,
+            });
+            console.debug('[shim][fetch][local] ->', u.toString());
+            return origFetch(cloned);
+          }
         }
 
         // cross-origin -> proxy through /proxy
@@ -193,11 +208,13 @@ function installRuntimeShims(originToId){
       xhr.open = function(method, url, async, user, pass){
         try {
           const u = new URL(url, ORIGIN);
-          if (u.origin === ORIGIN && u.pathname.startsWith('/socket.io')) {
+          if (u.origin === ORIGIN) {
             const id = pickOverlayIdFor(u.toString());
-            if (id) u.searchParams.set('overlay', id);
-            console.debug('[shim][xhr][local] ->', u.toString());
-            return open.call(xhr, method, u.toString(), async !== false, user, pass);
+            if (id) {
+              u.searchParams.set('overlay', id);
+              console.debug('[shim][xhr][local] ->', u.toString());
+              return open.call(xhr, method, u.toString(), async !== false, user, pass);
+            }
           }
         } catch {}
         return open.call(xhr, method, url, async, user, pass);
@@ -238,7 +255,7 @@ async function mountDomOverlay(ov){
   container.innerHTML = html;
   shadow.append(container);
 
-  executeScriptsSequentially(container);
+  await executeScriptsSequentially(container, ov.id);
 
   root.appendChild(host);
   window.overlayAPI.register(ov, host);
@@ -311,19 +328,21 @@ function injectRuntimeShimsFor(overlayId){
     const OVERLAY_ID = ${JSON.stringify(overlayId)};
     const ORIGIN = location.origin;
 
-    // WebSocket tunnel for cross-origin
+    // WebSocket shim
     (function(){
       const OrigWS = window.WebSocket;
       function tunneled(url, protocols){
         try {
           const u = new URL(url, ORIGIN);
-          if (u.origin !== ORIGIN) {
-            const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
-            const target = encodeURIComponent(u.toString());
-            const ov = OVERLAY_ID ? ('&overlay='+encodeURIComponent(OVERLAY_ID)) : '';
-            const turl = scheme + '://' + location.host + '/__ws?target=' + target + ov;
-            return new OrigWS(turl, protocols);
+          if (u.origin === ORIGIN) {
+            if (OVERLAY_ID) u.searchParams.set('overlay', OVERLAY_ID);
+            return new OrigWS(u.toString(), protocols);
           }
+          const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
+          const target = encodeURIComponent(u.toString());
+          const ov = OVERLAY_ID ? ('&overlay='+encodeURIComponent(OVERLAY_ID)) : '';
+          const turl = scheme + '://' + location.host + '/__ws?target=' + target + ov;
+          return new OrigWS(turl, protocols);
         } catch {}
         return new OrigWS(url, protocols);
       }
@@ -333,38 +352,59 @@ function injectRuntimeShimsFor(overlayId){
       window.WebSocket = tunneled;
     })();
 
-    // fetch shim for cross-origin
+    // fetch shim
     (function(){
       const origFetch = window.fetch;
       window.fetch = function(input, init){
         try{
-          const u = new URL(typeof input === 'string' ? input : input.url, ORIGIN);
-          if (u.origin !== ORIGIN) {
-            const prox = '/proxy?overlay='+encodeURIComponent(OVERLAY_ID)+'&url='+encodeURIComponent(u.toString());
-            // preserve method/body/headers as best we can
-            const opts = Object.assign({ credentials: 'include' }, init || {});
-            return origFetch(prox, opts);
+          const req = (input instanceof Request) ? input : new Request(input, init);
+          const u = new URL(req.url, ORIGIN);
+          if (u.origin === ORIGIN) {
+            if (OVERLAY_ID) u.searchParams.set('overlay', OVERLAY_ID);
+            const cloned = new Request(u.toString(), {
+              method: req.method,
+              headers: req.headers,
+              body: (req.method === 'GET' || req.method === 'HEAD') ? undefined : req.body,
+              redirect: req.redirect,
+              referrer: req.referrer, referrerPolicy: req.referrerPolicy,
+              mode: 'same-origin', credentials: 'include',
+              cache: req.cache, integrity: req.integrity,
+              keepalive: req.keepalive, signal: req.signal,
+            });
+            return origFetch(cloned);
           }
+          const prox = '/proxy?overlay='+encodeURIComponent(OVERLAY_ID)+'&url='+encodeURIComponent(u.toString());
+          const cloned = new Request(prox, {
+            method: req.method,
+            headers: req.headers,
+            body: (req.method === 'GET' || req.method === 'HEAD') ? undefined : req.body,
+            redirect: req.redirect,
+            referrer: req.referrer, referrerPolicy: req.referrerPolicy,
+            mode: 'same-origin', credentials: 'include',
+            cache: req.cache, integrity: req.integrity,
+            keepalive: req.keepalive, signal: req.signal,
+          });
+          return origFetch(cloned);
         } catch {}
         return origFetch(input, init);
       };
     })();
 
-    // XHR shim for cross-origin
+    // XHR shim
     (function(){
       const Orig = window.XMLHttpRequest;
       function X(){
         const xhr = new Orig();
-        let _url = null, _method = 'GET', _async = true;
         const open = xhr.open;
         xhr.open = function(method, url, async, user, pass){
           try {
             const u = new URL(url, ORIGIN);
-            if (u.origin !== ORIGIN) {
-              _url = '/proxy?overlay='+encodeURIComponent(OVERLAY_ID)+'&url='+encodeURIComponent(u.toString());
-              _method = method; _async = async !== false;
-              return open.call(xhr, method, _url, _async, user, pass);
+            if (u.origin === ORIGIN) {
+              if (OVERLAY_ID) u.searchParams.set('overlay', OVERLAY_ID);
+              return open.call(xhr, method, u.toString(), async !== false, user, pass);
             }
+            const prox = '/proxy?overlay='+encodeURIComponent(OVERLAY_ID)+'&url='+encodeURIComponent(u.toString());
+            return open.call(xhr, method, prox, async !== false, user, pass);
           } catch {}
           return open.call(xhr, method, url, async, user, pass);
         };


### PR DESCRIPTION
## Summary
- Ensure light DOM overlays append `overlay` query parameter to same-origin WebSocket, fetch, and XHR requests
- Fall back to proxying cross-origin requests through `/proxy` or `/__ws` with overlay IDs attached

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ced938fb883308123e18a968a29f0