### PR TITLE
Infer overlay ID from referer for proxy routes

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
   "canvas": { "width": 1920, "height": 1080, "background": "transparent" },
   "cacheSeconds": 60,
+  "defaultOverlay": "Twitchat",
   "overlays": [
     {
       "id": "Twitchat",


### PR DESCRIPTION
## Summary
- infer overlay ID from request query, Referer, or configured default
- tag proxied requests with cookies, Origin, and Referer headers
- warn when overlay cannot be determined

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d20a4f0688330af19c97e2a56e0bc