### PR TITLE
Add unit tests for runtime shims and control bus reconnection

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "dev": "node --watch src/server.mjs",
-    "start": "NODE_ENV=production node src/server.mjs"
+    "start": "NODE_ENV=production node src/server.mjs",
+    "test": "node --test test/index.test.mjs"
   },
   "dependencies": {
     "cheerio": "^1.0.0",

--- a/public/compositor.mjs
+++ b/public/compositor.mjs
@@ -1,4 +1,5 @@
 import config from '/config.js';
+import { installRuntimeShims, connectControlBus } from './runtime-shims.mjs';
 
 // Assuming you already imported config as 'config'
 window.overlayConfig = config; // if not already set
@@ -90,140 +91,6 @@ async function executeScriptsSequentiallyInDocument(scripts, overlayId){
     window.__ovLastOverlay = { id, t: performance.now() };
     window.__ovActiveOverlay = prev;
   }
-}
-
-function installRuntimeShims(originToId){
-  if (window.__ovShimsInstalled) return;
-  window.__ovShimsInstalled = true;
-
-  const ORIGIN = location.origin;
-  window.__ovOriginMap = originToId || {};
-
-  function pickOverlayIdFor(url) {
-    // 1) active overlay if set
-    if (window.__ovActiveOverlay) return window.__ovActiveOverlay;
-    // 2) recent overlay within last 6s
-    const last = window.__ovLastOverlay;
-    if (last && performance.now() - last.t < 6000) return last.id;
-    // 3) by absolute origin map (for cross-origin only)
-    try { return window.__ovOriginMap[new URL(url, ORIGIN).origin]; } catch { return undefined; }
-  }
-
-  // ---- WebSocket shim ----
-  (function(){
-    const OrigWS = window.WebSocket;
-    function addOverlayParam(u) {
-      const id = pickOverlayIdFor(u.toString());
-      if (!id) return u.toString();
-      u.searchParams.set('overlay', id);
-      return u.toString();
-    }
-    function tunneled(url, protocols){
-      try {
-        const u = new URL(url, ORIGIN);
-
-        // never touch our control bus
-        if (u.pathname === '/_control') return new OrigWS(url, protocols);
-
-        // SAME HOST: add overlay=<id> and connect locally
-        if (u.host === location.host) {
-          const withId = addOverlayParam(u);
-          console.debug('[shim][ws][local] ->', withId);
-          return new OrigWS(withId, protocols);
-        }
-
-        // CROSS ORIGIN: tunnel via /__ws (also pass overlay for cookies/origin spoof)
-        if (u.origin !== ORIGIN) {
-          const id = pickOverlayIdFor(u.toString());
-          const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
-          const ov = id ? '&overlay=' + encodeURIComponent(id) : '';
-          const turl = `${scheme}://${location.host}/__ws?target=${encodeURIComponent(u.toString())}${ov}`;
-          console.debug('[shim][ws][tunnel] ->', turl, '(', u.toString(), ')');
-          return new OrigWS(turl, protocols);
-        }
-      } catch {}
-      return new OrigWS(url, protocols);
-    }
-    ['CONNECTING','OPEN','CLOSING','CLOSED'].forEach(k => { tunneled[k] = OrigWS[k]; });
-    tunneled.prototype = OrigWS.prototype;
-    window.WebSocket = tunneled;
-  })();
-
-  // ---- fetch shim ----
-  (function(){
-    const origFetch = window.fetch;
-    window.fetch = function(input, init){
-      try{
-        const req = (input instanceof Request) ? input : new Request(input, init);
-        const u = new URL(req.url, ORIGIN);
-
-        // same-origin -> add overlay=<id>
-        if (u.origin === ORIGIN) {
-          const id = pickOverlayIdFor(u.toString());
-          if (id) {
-            u.searchParams.set('overlay', id);
-            const cloned = new Request(u.toString(), {
-              method: req.method,
-              headers: req.headers,
-              body: (req.method === 'GET' || req.method === 'HEAD') ? undefined : req.body,
-              redirect: req.redirect,
-              referrer: req.referrer, referrerPolicy: req.referrerPolicy,
-              mode: 'same-origin', credentials: 'include',
-              cache: req.cache, integrity: req.integrity,
-              keepalive: req.keepalive, signal: req.signal,
-            });
-            console.debug('[shim][fetch][local] ->', u.toString());
-            return origFetch(cloned);
-          }
-        }
-
-        // cross-origin -> proxy through /proxy
-        if (u.origin !== ORIGIN) {
-          const id = pickOverlayIdFor(u.toString());
-          const prox = `/proxy?${id ? `overlay=${encodeURIComponent(id)}&` : ''}url=${encodeURIComponent(u.toString())}`;
-          const cloned = new Request(prox, {
-            method: req.method,
-            headers: req.headers,
-            body: (req.method === 'GET' || req.method === 'HEAD') ? undefined : req.body,
-            redirect: req.redirect,
-            referrer: req.referrer, referrerPolicy: req.referrerPolicy,
-            mode: 'same-origin', credentials: 'include',
-            cache: req.cache, integrity: req.integrity,
-            keepalive: req.keepalive, signal: req.signal,
-          });
-          console.debug('[shim][fetch][proxy] ->', prox, '(', u.toString(), ')');
-          return origFetch(cloned);
-        }
-      } catch {}
-      return origFetch(input, init);
-    };
-  })();
-
-  // ---- XHR shim ----
-  (function(){
-    const Orig = window.XMLHttpRequest;
-    function X(){
-      const xhr = new Orig();
-      const open = xhr.open;
-      xhr.open = function(method, url, async, user, pass){
-        try {
-          const u = new URL(url, ORIGIN);
-          if (u.origin === ORIGIN) {
-            const id = pickOverlayIdFor(u.toString());
-            if (id) {
-              u.searchParams.set('overlay', id);
-              console.debug('[shim][xhr][local] ->', u.toString());
-              return open.call(xhr, method, u.toString(), async !== false, user, pass);
-            }
-          }
-        } catch {}
-        return open.call(xhr, method, url, async, user, pass);
-      };
-      return xhr;
-    }
-    X.prototype = Orig.prototype;
-    window.XMLHttpRequest = X;
-  })();
 }
 
 async function mountDomOverlay(ov){
@@ -466,22 +333,7 @@ async function main(){
   }
 }
 
-(function connectControlBus(){
-  try {
-    const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
-    const ws = new WebSocket(`${scheme}://${location.host}/_control`);
-
-    ws.onmessage = async (ev) => {
-      try {
-        const msg = JSON.parse(ev.data);
-        if (msg.type === 'reload') await window.overlayAPI.reload(msg.id);
-        if (msg.type === 'visibility' && msg.id) window.overlayAPI.setVisible(msg.id, !!msg.visible);
-      } catch (e) { console.error('control message error', e); }
-    };
-
-    ws.onclose = () => setTimeout(connectControlBus, 2000);
-  } catch {}
-})();
+connectControlBus();
 
 // Global-ish registry so control messages can reach overlays
 window.overlayAPI = (function(){

--- a/public/runtime-shims.mjs
+++ b/public/runtime-shims.mjs
@@ -1,0 +1,147 @@
+export function installRuntimeShims(originToId){
+  if (window.__ovShimsInstalled) return;
+  window.__ovShimsInstalled = true;
+
+  const ORIGIN = location.origin;
+  window.__ovOriginMap = originToId || {};
+
+  function pickOverlayIdFor(url) {
+    if (window.__ovActiveOverlay) return window.__ovActiveOverlay;
+    const last = window.__ovLastOverlay;
+    if (last && performance.now() - last.t < 6000) return last.id;
+    try { return window.__ovOriginMap[new URL(url, ORIGIN).origin]; } catch { return undefined; }
+  }
+
+  // ---- WebSocket shim ----
+  (function(){
+    const OrigWS = window.WebSocket;
+    function addOverlayParam(u) {
+      const id = pickOverlayIdFor(u.toString());
+      if (!id) return u.toString();
+      u.searchParams.set('overlay', id);
+      return u.toString();
+    }
+    function tunneled(url, protocols){
+      try {
+        const u = new URL(url, ORIGIN);
+
+        // never touch our control bus
+        if (u.pathname === '/_control') return new OrigWS(url, protocols);
+
+        // SAME HOST: add overlay=<id> and connect locally
+        if (u.host === location.host) {
+          const withId = addOverlayParam(u);
+          console.debug('[shim][ws][local] ->', withId);
+          return new OrigWS(withId, protocols);
+        }
+
+        // CROSS ORIGIN: tunnel via /__ws (also pass overlay for cookies/origin spoof)
+        if (u.origin !== ORIGIN) {
+          const id = pickOverlayIdFor(u.toString());
+          const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
+          const ov = id ? '&overlay=' + encodeURIComponent(id) : '';
+          const turl = `${scheme}://${location.host}/__ws?target=${encodeURIComponent(u.toString())}${ov}`;
+          console.debug('[shim][ws][tunnel] ->', turl, '(', u.toString(), ')');
+          return new OrigWS(turl, protocols);
+        }
+      } catch {}
+      return new OrigWS(url, protocols);
+    }
+    ['CONNECTING','OPEN','CLOSING','CLOSED'].forEach(k => { tunneled[k] = OrigWS[k]; });
+    tunneled.prototype = OrigWS.prototype;
+    window.WebSocket = tunneled;
+  })();
+
+  // ---- fetch shim ----
+  (function(){
+    const origFetch = window.fetch;
+    window.fetch = function(input, init){
+      try{
+        const req = (input instanceof Request) ? input : new Request(input, init);
+        const u = new URL(req.url, ORIGIN);
+
+        // same-origin -> add overlay=<id>
+        if (u.origin === ORIGIN) {
+          const id = pickOverlayIdFor(u.toString());
+          if (id) {
+            u.searchParams.set('overlay', id);
+            const cloned = new Request(u.toString(), {
+              method: req.method,
+              headers: req.headers,
+              body: (req.method === 'GET' || req.method === 'HEAD') ? undefined : req.body,
+              redirect: req.redirect,
+              referrer: req.referrer, referrerPolicy: req.referrerPolicy,
+              mode: 'same-origin', credentials: 'include',
+              cache: req.cache, integrity: req.integrity,
+              keepalive: req.keepalive, signal: req.signal,
+            });
+            console.debug('[shim][fetch][local] ->', u.toString());
+            return origFetch(cloned);
+          }
+        }
+
+        // cross-origin -> proxy through /proxy
+        if (u.origin !== ORIGIN) {
+          const id = pickOverlayIdFor(u.toString());
+          const prox = `/proxy?${id ? `overlay=${encodeURIComponent(id)}&` : ''}url=${encodeURIComponent(u.toString())}`;
+          const cloned = new Request(prox, {
+            method: req.method,
+            headers: req.headers,
+            body: (req.method === 'GET' || req.method === 'HEAD') ? undefined : req.body,
+            redirect: req.redirect,
+            referrer: req.referrer, referrerPolicy: req.referrerPolicy,
+            mode: 'same-origin', credentials: 'include',
+            cache: req.cache, integrity: req.integrity,
+            keepalive: req.keepalive, signal: req.signal,
+          });
+          console.debug('[shim][fetch][proxy] ->', prox, '(', u.toString(), ')');
+          return origFetch(cloned);
+        }
+      } catch {}
+      return origFetch(input, init);
+    };
+  })();
+
+  // ---- XHR shim ----
+  (function(){
+    const Orig = window.XMLHttpRequest;
+    function X(){
+      const xhr = new Orig();
+      const open = xhr.open;
+      xhr.open = function(method, url, async, user, pass){
+        try {
+          const u = new URL(url, ORIGIN);
+          if (u.origin === ORIGIN) {
+            const id = pickOverlayIdFor(u.toString());
+            if (id) {
+              u.searchParams.set('overlay', id);
+              console.debug('[shim][xhr][local] ->', u.toString());
+              return open.call(xhr, method, u.toString(), async !== false, user, pass);
+            }
+          }
+        } catch {}
+        return open.call(xhr, method, url, async, user, pass);
+      };
+      return xhr;
+    }
+    X.prototype = Orig.prototype;
+    window.XMLHttpRequest = X;
+  })();
+}
+
+export function connectControlBus(){
+  try {
+    const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${scheme}://${location.host}/_control`);
+
+    ws.onmessage = async (ev) => {
+      try {
+        const msg = JSON.parse(ev.data);
+        if (msg.type === 'reload') await window.overlayAPI.reload(msg.id);
+        if (msg.type === 'visibility' && msg.id) window.overlayAPI.setVisible(msg.id, !!msg.visible);
+      } catch (e) { console.error('control message error', e); }
+    };
+
+    ws.onclose = () => setTimeout(connectControlBus, 2000);
+  } catch {}
+}

--- a/test/control-bus.test.mjs
+++ b/test/control-bus.test.mjs
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { WebSocketServer, WebSocket } from 'ws';
+import { connectControlBus } from '../public/runtime-shims.mjs';
+
+test('control bus reconnects after socket close', async () => {
+  const port = 12345;
+  let connections = 0;
+  const wss = new WebSocketServer({ port, path: '/_control' });
+  wss.on('connection', ws => {
+    connections++;
+    if (connections === 1) ws.close();
+  });
+
+  const window = {
+    location: new URL(`http://localhost:${port}`),
+    WebSocket,
+    overlayAPI: { reload: () => {}, setVisible: () => {} },
+  };
+
+  const originalSetTimeout = global.setTimeout;
+  const immediate = (fn) => { originalSetTimeout(fn, 0); return 0; };
+  global.setTimeout = immediate;
+  global.window = window;
+  global.location = window.location;
+
+  connectControlBus();
+  await new Promise(r => originalSetTimeout(r, 50));
+
+  assert.ok(connections >= 2);
+
+  wss.close();
+  global.setTimeout = originalSetTimeout;
+});

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -1,0 +1,2 @@
+import './control-bus.test.mjs';
+import './shims.test.mjs';

--- a/test/shims.test.mjs
+++ b/test/shims.test.mjs
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { installRuntimeShims } from '../public/runtime-shims.mjs';
+
+test('fetch and XHR shims tag same-origin and proxy cross-origin requests', async () => {
+  const calls = [];
+  const ORIGIN = 'http://app.test';
+
+  const window = {
+    location: new URL(ORIGIN),
+    fetch: (input, init) => {
+      const url = input instanceof Request ? input.url : new URL(String(input), ORIGIN).toString();
+      calls.push(url);
+      return Promise.resolve(new Response('ok'));
+    },
+    XMLHttpRequest: class {
+      open(method, url){ calls.push(url); }
+    },
+    WebSocket: class {},
+    __ovActiveOverlay: 'ov1',
+    performance: { now: () => 0 },
+  };
+
+  global.window = window;
+  global.location = window.location;
+  global.performance = window.performance;
+  class Req extends Request {
+    constructor(input, init){
+      if (typeof input === 'string' && !/^https?:/i.test(input)) input = new URL(input, ORIGIN).toString();
+      super(input, init);
+    }
+  }
+  global.Request = window.Request = Req;
+
+  installRuntimeShims({});
+
+  await window.fetch('http://app.test/socket.io/');
+  await window.fetch('https://ext.test/data');
+
+  const xhr = new window.XMLHttpRequest();
+  xhr.open('GET', '/socket.io/data');
+
+  assert.strictEqual(calls[0], 'http://app.test/socket.io/?overlay=ov1');
+  assert.strictEqual(calls[1], 'http://app.test/proxy?overlay=ov1&url=https%3A%2F%2Fext.test%2Fdata');
+  assert.strictEqual(calls[2], 'http://app.test/socket.io/data?overlay=ov1');
+});


### PR DESCRIPTION
## Summary
- factor WebSocket/fetch/XMLHttpRequest shims and control-bus reconnect logic into `public/runtime-shims.mjs`
- exercise shims to ensure overlay IDs are tagged locally and proxied cross-origin
- verify control bus sockets reconnect after closures
- wire tests into `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d20ab520c83308cad18c88f569bdf