### PR TITLE
test: refetch asset after failure

### DIFF
--- a/test/overlayFetcher.test.mjs
+++ b/test/overlayFetcher.test.mjs
@@ -102,3 +102,34 @@ test('caches assets per overlay id', async () => {
     assert.equal(calls, 2);
   });
 });
+
+test('does not cache failed assets', async () => {
+  await withMock(async (mockAgent) => {
+    const origin = 'https://example.com';
+    const url = origin + '/asset.js';
+    const client = mockAgent.get(origin);
+    let calls = 0;
+    client
+      .intercept({ path: '/asset.js', method: 'GET' })
+      .reply(500, () => {
+        calls++;
+        return 'err';
+      }, { headers: { 'content-type': 'text/plain' } });
+    client
+      .intercept({ path: '/asset.js', method: 'GET' })
+      .reply(200, () => {
+        calls++;
+        return 'ok';
+      }, { headers: { 'content-type': 'text/plain' } });
+
+    const first = await fetchAsset(url, 60, {}, 'a');
+    assert.equal(first.ok, false);
+    assert.equal(first.status, 500);
+
+    const second = await fetchAsset(url, 60, {}, 'a');
+    assert.equal(second.ok, true);
+    assert.equal(second.buf.toString(), 'ok');
+
+    assert.equal(calls, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- add test for fetchAsset to ensure failures are not cached

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d68613f7c8330b1fd02b47e9b4605