### PR TITLE
Add server utility tests for overlay ID inference

### DIFF
--- a/src/server_utils.mjs
+++ b/src/server_utils.mjs
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const cfg = JSON.parse(fs.readFileSync(path.join(__dirname, '../config/default.json'), 'utf8'));
+
+export function getOverlayById(id){ return (cfg.overlays || []).find(o => o.id === id); }
+
+export function originOf(ov){ try { return new URL(ov.url).origin; } catch { return ''; } }
+
+export function parseBaseFromReferer(req) {
+  try {
+    const ref = req.headers.referer || '';
+    if (!ref) return {};
+    const ru = new URL(ref);
+    if (ru.pathname === '/proxy') {
+      return {
+        overlayId: ru.searchParams.get('overlay') || undefined,
+        baseUrl: ru.searchParams.get('url') || undefined
+      };
+    }
+    const m = ru.pathname.match(/\/overlay\/([^\/?#]+)/);
+    if (m) {
+      const overlayId = m[1];
+      const ov = getOverlayById(overlayId);
+      if (ov) return { overlayId, baseUrl: ov.url };
+    }
+  } catch {}
+  return {};
+}
+
+export function guessOverlayFromReferer(req){
+  const ref = req.headers.referer || '';
+  const m = ref.match(/\/overlay\/([^\/?#]+)/);
+  return m ? m[1] : null;
+}
+
+export function inferOverlayId(req){
+  return (
+    req.query.overlay ||
+    parseBaseFromReferer(req).overlayId ||
+    cfg.defaultOverlay ||
+    null
+  );
+}

--- a/test/server_utils.test.mjs
+++ b/test/server_utils.test.mjs
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+import { parseBaseFromReferer, inferOverlayId, cfg } from '../src/server_utils.mjs';
+
+test('parseBaseFromReferer handles /proxy?overlay=id&url=...', () => {
+  const req = {
+    headers: {
+      referer: 'http://localhost/proxy?overlay=blerps&url=' + encodeURIComponent('https://example.com/page')
+    }
+  };
+  const out = parseBaseFromReferer(req);
+  assert.equal(out.overlayId, 'blerps');
+  assert.equal(out.baseUrl, 'https://example.com/page');
+});
+
+test('parseBaseFromReferer handles /overlay/:id', () => {
+  const req = {
+    headers: {
+      referer: 'http://localhost/overlay/Twitchat'
+    }
+  };
+  const out = parseBaseFromReferer(req);
+  assert.equal(out.overlayId, 'Twitchat');
+  const expected = cfg.overlays.find(o => o.id === 'Twitchat').url;
+  assert.equal(out.baseUrl, expected);
+});
+
+test('inferOverlayId prioritizes query, then referer, then default', () => {
+  const defaultOverlay = cfg.defaultOverlay;
+
+  // query param wins
+  assert.equal(
+    inferOverlayId({
+      query: { overlay: 'streamelements' },
+      headers: { referer: 'http://localhost/overlay/blerps' }
+    }),
+    'streamelements'
+  );
+
+  // referer if query missing
+  assert.equal(
+    inferOverlayId({
+      query: {},
+      headers: { referer: 'http://localhost/overlay/blerps' }
+    }),
+    'blerps'
+  );
+
+  // default if neither
+  assert.equal(
+    inferOverlayId({ query: {}, headers: {} }),
+    defaultOverlay
+  );
+});


### PR DESCRIPTION
## Summary
- move overlay ID helper functions into `server_utils.mjs`
- add tests for referer parsing and overlay ID inference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d6a4b482083309f0a983709f55071