### PR TITLE
test: add keyframes scoping test

### DIFF
--- a/test/css_scope.test.mjs
+++ b/test/css_scope.test.mjs
@@ -12,3 +12,12 @@ test('scopeCss prefixes selectors and rewrites roots', async () => {
   assert.equal(lines[2], `:where(${scope}) .a{padding:1px}`);
   assert.equal(lines[3], `:where(${scope}){--x:1}`);
 });
+
+test('scopeCss ignores keyframes inner selectors', async () => {
+  const scope = '[data-ov=test]';
+  const css = `@keyframes fade{from{opacity:0}to{opacity:1}}\n.b{animation:fade 1s}`;
+  const out = await scopeCss(css, scope);
+  const lines = out.trim().split(/\n/);
+  assert.equal(lines[0], '@keyframes fade{from{opacity:0}to{opacity:1}}');
+  assert.equal(lines[1], `:where(${scope}) .b{animation:fade 1s}`);
+});


### PR DESCRIPTION
## Summary
- verify keyframe rules are not scoped by `scopeCss`

## Testing
- `node --test test/css_scope.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_689d6c8801d08330bc98290d5ff5e1f4