### PR TITLE
feat: ensure worker network shims and controllable control bus reconnect

### DIFF
--- a/public/runtime-shims.mjs
+++ b/public/runtime-shims.mjs
@@ -12,6 +12,97 @@ export function installRuntimeShims(originToId){
     try { return window.__ovOriginMap[new URL(url, ORIGIN).origin]; } catch { return undefined; }
   }
 
+  function workerShimGlobal(){
+    const ORIGIN = self.location.origin;
+    const OVERLAY_ID = self.__ovOverlayId;
+
+    (function(){
+      const OrigWS = self.WebSocket;
+      function addOverlay(u){
+        if (OVERLAY_ID) u.searchParams.set('overlay', OVERLAY_ID);
+        return u.toString();
+      }
+      function tunneled(url, protocols){
+        try {
+          const u = new URL(url, ORIGIN);
+          if (u.host === self.location.host) return new OrigWS(addOverlay(u), protocols);
+          if (u.origin !== ORIGIN) {
+            const scheme = self.location.protocol === 'https:' ? 'wss' : 'ws';
+            const ov = OVERLAY_ID ? '&overlay=' + encodeURIComponent(OVERLAY_ID) : '';
+            const turl = scheme + '://' + self.location.host + '/__ws?target=' + encodeURIComponent(u.toString()) + ov;
+            return new OrigWS(turl, protocols);
+          }
+        } catch {}
+        return new OrigWS(url, protocols);
+      }
+      ['CONNECTING','OPEN','CLOSING','CLOSED'].forEach(k => { tunneled[k] = OrigWS[k]; });
+      tunneled.prototype = OrigWS.prototype;
+      self.WebSocket = tunneled;
+    })();
+
+    (function(){
+      const origFetch = self.fetch;
+      self.fetch = function(input, init){
+        try {
+          const req = (input instanceof Request) ? input : new Request(input, init);
+          const u = new URL(req.url, ORIGIN);
+          if (u.origin === ORIGIN) {
+            if (OVERLAY_ID) u.searchParams.set('overlay', OVERLAY_ID);
+            const cloned = new Request(u.toString(), {
+              method: req.method,
+              headers: req.headers,
+              body: (req.method === 'GET' || req.method === 'HEAD') ? undefined : req.body,
+              redirect: req.redirect,
+              referrer: req.referrer, referrerPolicy: req.referrerPolicy,
+              mode: 'same-origin', credentials: 'include',
+              cache: req.cache, integrity: req.integrity,
+              keepalive: req.keepalive, signal: req.signal,
+            });
+            return origFetch(cloned);
+          }
+          const prox = '/proxy?' + (OVERLAY_ID ? 'overlay=' + encodeURIComponent(OVERLAY_ID) + '&' : '') + 'url=' + encodeURIComponent(u.toString());
+          const cloned = new Request(prox, {
+            method: req.method,
+            headers: req.headers,
+            body: (req.method === 'GET' || req.method === 'HEAD') ? undefined : req.body,
+            redirect: req.redirect,
+            referrer: req.referrer, referrerPolicy: req.referrerPolicy,
+            mode: 'same-origin', credentials: 'include',
+            cache: req.cache, integrity: req.integrity,
+            keepalive: req.keepalive, signal: req.signal,
+          });
+          return origFetch(cloned);
+        } catch {}
+        return origFetch(input, init);
+      };
+    })();
+
+    (function(){
+      const Orig = self.XMLHttpRequest;
+      function X(){
+        const xhr = new Orig();
+        const open = xhr.open;
+        xhr.open = function(method, url, async, user, pass){
+          try {
+            const u = new URL(url, ORIGIN);
+            if (u.origin === ORIGIN) {
+              if (OVERLAY_ID) u.searchParams.set('overlay', OVERLAY_ID);
+              return open.call(xhr, method, u.toString(), async !== false, user, pass);
+            }
+            const prox = '/proxy?' + (OVERLAY_ID ? 'overlay=' + encodeURIComponent(OVERLAY_ID) + '&' : '') + 'url=' + encodeURIComponent(u.toString());
+            return open.call(xhr, method, prox, async !== false, user, pass);
+          } catch {}
+          return open.call(xhr, method, url, async, user, pass);
+        };
+        return xhr;
+      }
+      X.prototype = Orig.prototype;
+      self.XMLHttpRequest = X;
+    })();
+  }
+
+  const WORKER_SHIM = '(' + workerShimGlobal.toString() + ')();';
+
   // ---- WebSocket shim ----
   (function(){
     const OrigWS = window.WebSocket;
@@ -127,21 +218,60 @@ export function installRuntimeShims(originToId){
     X.prototype = Orig.prototype;
     window.XMLHttpRequest = X;
   })();
+
+  // ---- Worker shim ----
+  (function(){
+    function wrap(Orig){
+      function W(url, opts){
+        try {
+          const u = new URL(url, ORIGIN);
+          const id = pickOverlayIdFor(u.toString());
+          let prox;
+          if (u.origin === ORIGIN) {
+            if (id) u.searchParams.set('overlay', id);
+            prox = u.toString();
+          } else {
+            const ov = id ? 'overlay=' + encodeURIComponent(id) + '&' : '';
+            prox = '/proxy?' + ov + 'url=' + encodeURIComponent(u.toString());
+          }
+          const boot = `self.__ovOverlayId=${id ? JSON.stringify(id) : 'undefined'};\n${WORKER_SHIM}\nimportScripts(${JSON.stringify(prox)});`;
+          const blob = new Blob([boot], { type: 'application/javascript' });
+          const obj = URL.createObjectURL(blob);
+          const w = new Orig(obj, opts);
+          setTimeout(() => URL.revokeObjectURL(obj), 0);
+          return w;
+        } catch {}
+        return new Orig(url, opts);
+      }
+      W.prototype = Orig.prototype;
+      return W;
+    }
+    if (window.Worker) window.Worker = wrap(window.Worker);
+    if (window.SharedWorker) window.SharedWorker = wrap(window.SharedWorker);
+  })();
 }
 
 export function connectControlBus(){
   try {
     const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
-    const ws = new WebSocket(`${scheme}://${location.host}/_control`);
+    let stopped = false;
+    let socket;
 
-    ws.onmessage = async (ev) => {
-      try {
-        const msg = JSON.parse(ev.data);
-        if (msg.type === 'reload') await window.overlayAPI.reload(msg.id);
-        if (msg.type === 'visibility' && msg.id) window.overlayAPI.setVisible(msg.id, !!msg.visible);
-      } catch (e) { console.error('control message error', e); }
-    };
+    function connect(){
+      socket = new WebSocket(`${scheme}://${location.host}/_control`);
 
-    ws.onclose = () => setTimeout(connectControlBus, 2000);
+      socket.onmessage = async (ev) => {
+        try {
+          const msg = JSON.parse(ev.data);
+          if (msg.type === 'reload') await window.overlayAPI.reload(msg.id);
+          if (msg.type === 'visibility' && msg.id) window.overlayAPI.setVisible(msg.id, !!msg.visible);
+        } catch (e) { console.error('control message error', e); }
+      };
+
+      socket.onclose = () => { if (!stopped) setTimeout(connect, 2000); };
+    }
+
+    connect();
+    return () => { stopped = true; try { socket.close(); } catch {} };
   } catch {}
 }

--- a/test/control-bus.test.mjs
+++ b/test/control-bus.test.mjs
@@ -24,11 +24,12 @@ test('control bus reconnects after socket close', async () => {
   global.window = window;
   global.location = window.location;
 
-  connectControlBus();
+  const stop = connectControlBus();
   await new Promise(r => originalSetTimeout(r, 50));
 
   assert.ok(connections >= 2);
 
+  stop();
   wss.close();
   global.setTimeout = originalSetTimeout;
 });


### PR DESCRIPTION
## Summary
- wrap Worker and SharedWorker so their scripts load through the proxy and reinstall fetch/WebSocket/XMLHttpRequest shims in worker scope
- allow control bus connector to be stopped, preventing runaway reconnection loops
- clean up control bus test to stop the connector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689df3cb8fe083308546393daed3e29a