### PR TITLE
refactor: use WS_PREFIXES for ws routing

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -450,7 +450,7 @@ const PORT = process.env.PORT || 4321;
 const server = app.listen(PORT, () => console.log(`[overlay-proxy] http://localhost:${PORT}`));
 
 // Which WS paths should we proxy to overlay origins?
-const WS_PREFIXES = ['/socket.io/', '/ws', '/realtime', '/live', '/cable']; // extend as needed
+const WS_PREFIXES = ['/socket.io', '/ws', '/realtime', '/live', '/cable']; // add new WS paths here
 
 server.on('upgrade', async (req, socket, head) => {
   // Avoid crashing on client socket errors (e.g. ECONNRESET)
@@ -467,8 +467,8 @@ server.on('upgrade', async (req, socket, head) => {
       });
     }
 
-    // socket.io & friends on our origin (keep your existing prefix check if you want)
-    if (path.startsWith('/socket.io') || path.startsWith('/ws') || path.startsWith('/realtime') || path.startsWith('/live')) {
+    // socket.io & friends on our origin (matches any prefix in WS_PREFIXES)
+    if (WS_PREFIXES.some(pfx => path.startsWith(pfx))) {
       const overlayId = url.searchParams.get('overlay');
       let candidates = [];
       if (overlayId) {

--- a/test/control-bus.test.mjs
+++ b/test/control-bus.test.mjs
@@ -25,7 +25,13 @@ test('control bus reconnects after socket close', async () => {
   global.location = window.location;
 
   const stop = connectControlBus();
-  await new Promise(r => originalSetTimeout(r, 50));
+  await new Promise((resolve) => {
+    const check = () => {
+      if (connections >= 2) return resolve();
+      originalSetTimeout(check, 10);
+    };
+    check();
+  });
 
   assert.ok(connections >= 2);
 


### PR DESCRIPTION
## Summary
- simplify websocket routing by looping over `WS_PREFIXES`
- document `WS_PREFIXES` for easy extension of websocket provider prefixes
- stabilize control bus reconnect test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e839ecea48330880b7ddb893653a6