### PR TITLE
feat: allow disabling overlay fetch cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ Backgrounds, sprites, fonts, and responsive images are now proxied (even when us
 
 ## Configuration
 On startup the proxy fetches each overlay URL and scans its HTML and linked scripts for `https://` and `wss://` references. Any domains it finds are tagged with the overlay ID so cookies and headers route correctly. You can still provide an `origins` array in the config to manually include extra hosts that aren't discoverable.
+
+### Disabling the fetch cache
+For troubleshooting overlay changes it's sometimes useful to bypass the in-memory cache. Set the environment variable `DISABLE_CACHE=1` or add `"useCache": false` to your config to disable caching of overlay pages and assets.

--- a/src/routes/genericProxy.mjs
+++ b/src/routes/genericProxy.mjs
@@ -1,4 +1,12 @@
-import { cfg, getOverlayById, originOf, parseBaseFromReferer, inferOverlayId, readRawBody, unwrapProxyUrl } from '../server_utils.mjs';
+import {
+  cfg,
+  getOverlayById,
+  originOf,
+  parseBaseFromReferer,
+  inferOverlayId,
+  readRawBody,
+  unwrapProxyUrl
+} from '../server_utils.mjs';
 import { fetchAsset } from '../overlayFetcher.mjs';
 import { getCookieHeader } from '../cookies.mjs';
 import { fetch } from 'undici';
@@ -21,7 +29,14 @@ export default function genericProxy(app){
       const headers = { ...req.headers, origin: originOf(ov), referer: ov.url };
       delete headers.host;
 
-      const upstream = await fetchAsset(resolvedUrl, cfg.cacheSeconds, headers, overlayId, ov.url);
+      const upstream = await fetchAsset(
+        resolvedUrl,
+        cfg.cacheSeconds,
+        headers,
+        overlayId,
+        ov.url,
+        cfg.useCache
+      );
 
       let outBuf = upstream.buf;
       let outType = upstream.type;
@@ -120,7 +135,8 @@ export default function genericProxy(app){
             cfg.cacheSeconds,
             req.headers,
             cand.overlayId,
-            cand.baseUrl
+            cand.baseUrl,
+            cfg.useCache
           );
 
           if (up.status === 404) continue;

--- a/src/routes/overlay.mjs
+++ b/src/routes/overlay.mjs
@@ -11,7 +11,16 @@ export default function overlayRoutes(app){
     const ov = getOverlayById(req.params.id);
     if (!ov) return res.status(404).send('Overlay not found');
     try {
-      const upstream = coercePage(await fetchOverlayPage(ov.url, cfg.cacheSeconds, req.headers, ov.id, ov.url));
+      const upstream = coercePage(
+        await fetchOverlayPage(
+          ov.url,
+          cfg.cacheSeconds,
+          req.headers,
+          ov.id,
+          ov.url,
+          cfg.useCache
+        )
+      );
       const { rewriteHtml } = await import('../rewrite_ext.mjs');
       const out = await rewriteHtml({ html: upstream.text || '', originUrl: ov.url, overlayId: ov.id });
       res.status(upstream.status).set('Content-Type', 'text/html; charset=utf-8').send(out);
@@ -24,7 +33,16 @@ export default function overlayRoutes(app){
     const ov = getOverlayById(req.params.id);
     if (!ov) return res.status(404).send('Overlay not found');
     try {
-      const upstream = coercePage(await fetchOverlayPage(ov.url, cfg.cacheSeconds, req.headers, ov.id, ov.url));
+      const upstream = coercePage(
+        await fetchOverlayPage(
+          ov.url,
+          cfg.cacheSeconds,
+          req.headers,
+          ov.id,
+          ov.url,
+          cfg.useCache
+        )
+      );
       const { rewriteHtml } = await import('../rewrite_ext.mjs');
       let html = await rewriteHtml({ html: upstream.text || '', originUrl: ov.url, overlayId: ov.id });
       const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
@@ -40,7 +58,16 @@ export default function overlayRoutes(app){
     if (!ov) return res.status(404).send('Overlay not found');
 
     try {
-      const upstream = coercePage(await fetchOverlayPage(ov.url, cfg.cacheSeconds, req.headers, ov.id, ov.url));
+      const upstream = coercePage(
+        await fetchOverlayPage(
+          ov.url,
+          cfg.cacheSeconds,
+          req.headers,
+          ov.id,
+          ov.url,
+          cfg.useCache
+        )
+      );
       const scopeSelector = ov.isolation === 'light' ? `[data-ov="${ov.id}"]` : undefined;
       const { rewriteHtml } = await import('../rewrite_ext.mjs');
       const html = await rewriteHtml({

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -24,6 +24,8 @@ app.use(compression());
 app.use(cors({ origin: process.env.ORIGIN_ALLOW || '*' }));
 app.use(express.json({ limit: '128kb' }));
 
+if (!cfg.useCache) console.log('[overlay-proxy] cache disabled');
+
 app.get('/config.json', (_req, res) => res.json(cfg));
 app.get('/config.js', (_req, res) => {
   res.setHeader('Content-Type', 'application/javascript; charset=utf-8');


### PR DESCRIPTION
## Summary
- add `useCache` flag and `DISABLE_CACHE` env var to overlayFetcher to bypass NodeCache
- plumb cache toggle through server config and log when disabled
- document cache-disabling option for debugging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec5c53ae48330bb188aa8763f263a