### PR TITLE
refactor: async overlay origin discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,14 @@ Backgrounds, sprites, fonts, and responsive images are now proxied (even when us
 ## Configuration
 On startup the proxy fetches each overlay URL and scans its HTML and linked scripts for `https://` and `wss://` references. Any domains it finds are tagged with the overlay ID so cookies and headers route correctly. You can still provide an `origins` array in the config to manually include extra hosts that aren't discoverable.
 
+To refresh origin discovery at runtime (after editing overlay URLs), send:
+
+```bash
+curl -X POST http://localhost:4321/api/discover \
+  -H "Authorization: Bearer $CONTROL_TOKEN"
+```
+
+The server will log any discovery failures but continue serving existing overlays.
+
 ### Disabling the fetch cache
 For troubleshooting overlay changes it's sometimes useful to bypass the in-memory cache. Set the environment variable `DISABLE_CACHE=1` or add `"useCache": false` to your config to disable caching of overlay pages and assets.


### PR DESCRIPTION
## Summary
- export discoverOverlayOrigins and log per-overlay discovery failures
- invoke overlay origin discovery during server boot
- add auth-protected /api/discover endpoint to rerun origin discovery

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f33e413e08330a69512181dcd57b2