### PR TITLE
refactor: centralize overlay ordering logic

### DIFF
--- a/src/routes/absPrefixProxy.mjs
+++ b/src/routes/absPrefixProxy.mjs
@@ -1,4 +1,4 @@
-import { cfg, getOverlayById, originOf, guessOverlayFromReferer, readRawBody } from '../server_utils.mjs';
+import { cfg, originOf, orderedOverlays, readRawBody } from '../server_utils.mjs';
 import { fetch } from 'undici';
 
 const ABS_PREFIXES = ['/cdn-cgi/', '/assets/', '/static/', '/build/', '/s/', '/dist/'];
@@ -7,10 +7,7 @@ export default function absPrefixProxy(app){
   for (const pfx of ABS_PREFIXES) {
     app.all(pfx + '*', async (req, res) => {
       try {
-        const ordered = [];
-        const fromRef = guessOverlayFromReferer(req);
-        if (fromRef) { const ov = getOverlayById(fromRef); if (ov) ordered.push(ov); }
-        for (const ov of (cfg.overlays || [])) if (!ordered.includes(ov)) ordered.push(ov);
+        const ordered = orderedOverlays(req, req.query.overlay);
 
         const pathWithQuery = req.originalUrl;
         let lastErr;

--- a/src/routes/genericProxy.mjs
+++ b/src/routes/genericProxy.mjs
@@ -5,7 +5,8 @@ import {
   parseBaseFromReferer,
   inferOverlayId,
   readRawBody,
-  unwrapProxyUrl
+  unwrapProxyUrl,
+  orderedOverlays
 } from '../server_utils.mjs';
 import { fetchAsset } from '../overlayFetcher.mjs';
 import { getCookieHeader } from '../cookies.mjs';
@@ -115,13 +116,10 @@ export default function genericProxy(app){
       const { overlayId, baseUrl } = parseBaseFromReferer(req);
       const filePath = req.path.replace(/^\//, '');
 
+      const ordered = orderedOverlays(req, overlayId);
       const candidates = [];
       if (baseUrl) candidates.push({ overlayId, baseUrl });
-      if (overlayId && !baseUrl) {
-        const ov = getOverlayById(overlayId);
-        if (ov) candidates.push({ overlayId, baseUrl: ov.url });
-      }
-      for (const ov of (cfg.overlays || [])) {
+      for (const ov of ordered) {
         if (!candidates.find(c => c.baseUrl === ov.url)) {
           candidates.push({ overlayId: ov.id, baseUrl: ov.url });
         }

--- a/src/routes/socketioProxy.mjs
+++ b/src/routes/socketioProxy.mjs
@@ -1,14 +1,11 @@
-import { cfg, getOverlayById, originOf, readRawBody } from '../server_utils.mjs';
+import { cfg, originOf, orderedOverlays, readRawBody } from '../server_utils.mjs';
 import { fetch } from 'undici';
 import { getCookieHeader } from '../cookies.mjs';
 
 export default function socketioProxy(app){
   app.all('/socket.io/*', async (req, res) => {
     try {
-      const ovParam = req.query.overlay;
-      const ordered = [];
-      if (ovParam) { const ov = getOverlayById(ovParam); if (ov) ordered.push(ov); }
-      for (const ov of (cfg.overlays || [])) if (!ordered.includes(ov)) ordered.push(ov);
+      const ordered = orderedOverlays(req, req.query.overlay);
 
       for (const ov of ordered) {
         const upstreamUrl = originOf(ov) + req.originalUrl.replace(/([?&])overlay=[^&]+&?/, '$1').replace(/[?&]$/, '');

--- a/src/server_utils.mjs
+++ b/src/server_utils.mjs
@@ -111,6 +111,19 @@ export function guessOverlayFromReferer(req){
   return m ? m[1] : null;
 }
 
+export function orderedOverlays(req, explicitId){
+  const ordered = [];
+  const push = id => {
+    const ov = getOverlayById(id);
+    if (ov && !ordered.includes(ov)) ordered.push(ov);
+  };
+  if (explicitId) push(explicitId);
+  const fromRef = guessOverlayFromReferer(req);
+  if (fromRef) push(fromRef);
+  for (const ov of (cfg.overlays || [])) if (!ordered.includes(ov)) ordered.push(ov);
+  return ordered;
+}
+
 export function inferOverlayId(req){
   return (
     req.query.overlay ||


### PR DESCRIPTION
## Summary
- add `orderedOverlays` helper to prioritize explicit overlay id then referer
- use shared helper in absPrefixProxy, genericProxy, and socketioProxy routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4769031c8330885518808a584d04