### PR TITLE
Refactor overlay routes with helper

### DIFF
--- a/src/routes/overlay.mjs
+++ b/src/routes/overlay.mjs
@@ -6,26 +6,47 @@ function coercePage(upstream) {
   return upstream || { ok: false, status: 502, text: '' };
 }
 
+async function fetchAndRewriteOverlay(ov, headers, scopeSelector) {
+  const upstream = coercePage(
+    await fetchOverlayPage(
+      ov.url,
+      cfg.cacheSeconds,
+      headers,
+      ov.id,
+      ov.url,
+      cfg.useCache
+    )
+  );
+  const { rewriteHtml } = await import('../rewrite_ext.mjs');
+  const html = await rewriteHtml({
+    html: upstream.text || '',
+    originUrl: ov.url,
+    overlayId: ov.id,
+    scopeSelector
+  });
+  return { status: upstream.status, html };
+}
+
 export default function overlayRoutes(app){
   app.get('/overlay/:id', async (req, res) => {
     const ov = getOverlayById(req.params.id);
     if (!ov) return res.status(404).send('Overlay not found');
     try {
-      const upstream = coercePage(
-        await fetchOverlayPage(
-          ov.url,
-          cfg.cacheSeconds,
-          req.headers,
-          ov.id,
-          ov.url,
-          cfg.useCache
-        )
-      );
-      const { rewriteHtml } = await import('../rewrite_ext.mjs');
-      const out = await rewriteHtml({ html: upstream.text || '', originUrl: ov.url, overlayId: ov.id });
-      res.status(upstream.status).set('Content-Type', 'text/html; charset=utf-8').send(out);
+      const { status, html } = await fetchAndRewriteOverlay(ov, req.headers);
+      res
+        .status(status)
+        .set('Content-Type', 'text/html; charset=utf-8')
+        .set('X-Resolved-Url', ov.url)
+        .set('X-Upstream-Status', String(status))
+        .set('X-Overlay', ov.id)
+        .send(html);
     } catch (e) {
-      res.status(502).set('X-Proxy-Error', 'overlay-full').send(String(e?.message || e));
+      res
+        .status(502)
+        .set('X-Proxy-Error', 'overlay-full')
+        .set('X-Resolved-Url', ov.url)
+        .set('X-Overlay', ov.id)
+        .send(String(e?.message || e));
     }
   });
 
@@ -33,23 +54,23 @@ export default function overlayRoutes(app){
     const ov = getOverlayById(req.params.id);
     if (!ov) return res.status(404).send('Overlay not found');
     try {
-      const upstream = coercePage(
-        await fetchOverlayPage(
-          ov.url,
-          cfg.cacheSeconds,
-          req.headers,
-          ov.id,
-          ov.url,
-          cfg.useCache
-        )
-      );
-      const { rewriteHtml } = await import('../rewrite_ext.mjs');
-      let html = await rewriteHtml({ html: upstream.text || '', originUrl: ov.url, overlayId: ov.id });
+      const { status, html } = await fetchAndRewriteOverlay(ov, req.headers);
       const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
       const fragment = bodyMatch ? bodyMatch[1] : html;
-      res.status(upstream.status).set('Content-Type', 'text/html; charset=utf-8').send(fragment);
+      res
+        .status(status)
+        .set('Content-Type', 'text/html; charset=utf-8')
+        .set('X-Resolved-Url', ov.url)
+        .set('X-Upstream-Status', String(status))
+        .set('X-Overlay', ov.id)
+        .send(fragment);
     } catch (e) {
-      res.status(502).set('X-Proxy-Error', 'overlay-fragment').send(String(e?.message || e));
+      res
+        .status(502)
+        .set('X-Proxy-Error', 'overlay-fragment')
+        .set('X-Resolved-Url', ov.url)
+        .set('X-Overlay', ov.id)
+        .send(String(e?.message || e));
     }
   });
 
@@ -58,35 +79,23 @@ export default function overlayRoutes(app){
     if (!ov) return res.status(404).send('Overlay not found');
 
     try {
-      const upstream = coercePage(
-        await fetchOverlayPage(
-          ov.url,
-          cfg.cacheSeconds,
-          req.headers,
-          ov.id,
-          ov.url,
-          cfg.useCache
-        )
-      );
       const scopeSelector = ov.isolation === 'light' ? `[data-ov="${ov.id}"]` : undefined;
-      const { rewriteHtml } = await import('../rewrite_ext.mjs');
-      const html = await rewriteHtml({
-        html: upstream.text || '',
-        originUrl: ov.url,
-        overlayId: ov.id,
-        scopeSelector
-      });
+      const { status, html } = await fetchAndRewriteOverlay(ov, req.headers, scopeSelector);
 
       res
-        .status(upstream.status)
+        .status(status)
         .set('Content-Type', 'text/html; charset=utf-8')
-        .set('X-Upstream-Status', String(upstream.status))
+        .set('X-Upstream-Status', String(status))
+        .set('X-Resolved-Url', ov.url)
+        .set('X-Overlay', ov.id)
         .send(html);
     } catch (e) {
       res
         .status(200)
         .set('Content-Type', 'text/html; charset=utf-8')
         .set('X-Proxy-Error', `overlay-full:${e?.message || e}`)
+        .set('X-Resolved-Url', ov.url)
+        .set('X-Overlay', ov.id)
         .send('<!doctype html><meta charset="utf-8"><body style="color:#f55;background:#111;font:14px/1.4 monospace;padding:12px">Overlay rewrite failed. Check console/network headers.<br>' + String(e?.message || e) + '</body>');
     }
   });


### PR DESCRIPTION
## Summary
- add `fetchAndRewriteOverlay` helper to centralize fetch/rewrite logic
- refactor overlay routes to use new helper and set diagnostic headers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f476b565c8330b401c00b93bb7bba