### PR TITLE
refactor: reuse host builder for iframe overlays

### DIFF
--- a/public/compositor.mjs
+++ b/public/compositor.mjs
@@ -134,15 +134,7 @@ async function mountDomOverlay(ov){
 }
 
 function mountIframeOverlay(ov){
-  const host = document.createElement('div');
-  host.className = 'overlay-host';
-  host.style.left = px(ov.x);
-  host.style.top = px(ov.y);
-  host.style.width = px(ov.width);
-  host.style.height = px(ov.height);
-  host.style.zIndex = String(ov.z ?? 0);
-  host.style.opacity = String(ov.opacity ?? 1);
-  host.style.transform = `scale(${ov.scale ?? 1})`;
+  const host = makeHost(ov);
 
   const iframe = document.createElement('iframe');
   iframe.className = 'overlay-iframe';


### PR DESCRIPTION
## Summary
- refactor iframe overlay mounting to use existing `makeHost`
- remove redundant style assignments and keep iframe logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f47749e988330b8b8b206d2345841